### PR TITLE
Feature: wait for TCP services

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ smlr is short for "sommelier", but easier to spell
 smlr can wait for several types of dependencies:
 
 - http
-- tcp (TODO)
+- tcp
 - script (TODO)
 
 Each of them has different use cases. In general, you should prefer to use HTTP

--- a/smlr/tcp.go
+++ b/smlr/tcp.go
@@ -1,0 +1,195 @@
+package smlr
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"bytes"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/jpillora/backoff"
+	"golang.org/x/net/context"
+)
+
+var errNoMatch = errors.New("no content match")
+var errNoMatchTimeout = errors.New("no content match within iotimeout")
+
+// TCPWaiter waits for an TCP call to return with specified content
+type TCPWaiter struct {
+	URL           string
+	Content       string
+	Write         string        // write this to the connection before listening
+	IOTimeout     time.Duration // how long to wait for the EOF before retrying
+	EntireContent bool
+}
+
+// Wait starts the waiting (this is entirely copied from http)
+func (t *TCPWaiter) Wait(ctx context.Context, interval, timeout time.Duration) chan *Status {
+	out := make(chan *Status, 1)
+
+	go t.startWaiting(ctx, out, interval, timeout)
+
+	return out
+}
+
+// startWaiting loops until the timeout is reached or we're done waiting
+// (this is entirely copied from http)
+func (t *TCPWaiter) startWaiting(ctx context.Context, out chan *Status, interval, timeout time.Duration) {
+	defer close(out)
+
+	boff := &backoff.Backoff{
+		Min:    500 * time.Millisecond,
+		Max:    3 * time.Second,
+		Jitter: true,
+	}
+
+	timedOut := time.After(timeout)
+	next := time.After(0)
+
+	for {
+		var status *Status
+		select {
+		case <-timedOut:
+			status = &Status{Done: true, Error: errors.New("timed out")}
+		case <-ctx.Done():
+			status = &Status{Done: true, Error: errors.New("cancelled, ceasing wait")}
+		case <-next:
+			status = t.request(ctx)
+		}
+
+		out <- status
+
+		if status.Done {
+			break
+		} else {
+			d := boff.Duration()
+			logrus.WithField("duration", d).Debug("backoff")
+			next = time.After(d)
+		}
+	}
+}
+
+// request actually sends the request over the network
+// TODO: how to use context?
+func (t *TCPWaiter) request(ctx context.Context) *Status {
+	conn, err := net.Dial("tcp", t.URL)
+	if conn != nil {
+		defer conn.Close()
+	}
+
+	// error matching
+	if err != nil {
+		switch err.(type) {
+		case *net.OpError:
+			switch err.(*net.OpError).Err.(type) {
+			case *net.DNSError:
+				return &Status{Done: false, Message: "could not reach host"}
+			case *os.SyscallError:
+				return &Status{Done: false, Message: "connection refused"}
+			case *net.AddrError:
+				return &Status{Done: false, Message: "connection refused"}
+			default:
+				return &Status{Error: err}
+			}
+		default:
+			return &Status{Error: err}
+		}
+	}
+
+	// writing to the connection
+	if t.Write != "" {
+		// add a newline to emulate the behavior of echo | nc
+		if !strings.HasSuffix(t.Write, "\n") {
+			t.Write += "\n"
+		}
+		// wait a maximum of IOtimeout to write our message
+		conn.SetDeadline(time.Now().Add(t.IOTimeout))
+		_, err = conn.Write([]byte(t.Write))
+		if err != nil {
+			return &Status{Done: true, Error: err}
+		}
+	}
+
+	// content matching
+	if t.Content != "" {
+		var content []byte
+
+		// handle the simple case: either match all or time out
+		if t.EntireContent {
+			conn.SetDeadline(time.Now().Add(t.IOTimeout))
+			content, err := ioutil.ReadAll(conn)
+			if err != nil {
+				if strings.Contains(err.Error(), "i/o timeout") {
+					return &Status{Done: true, Error: errNoMatchTimeout}
+				}
+				return &Status{Done: true, Error: err}
+			}
+			if bytes.Equal(content, []byte(t.Content)) {
+				return &Status{Done: true, Message: "service available"}
+			}
+			return &Status{Done: true, Error: errNoMatch}
+		}
+
+		// match the content progressively as it arrives
+
+		read := make(chan byte)  // the bytes we've read so far
+		eof := make(chan bool)   // have we read all of them?
+		errs := make(chan error) // have we encountered an error while reading?
+		reader := bufio.NewReader(conn)
+
+		// send all the bytes down a channel as they come over the network
+		go func(rdr *bufio.Reader, out chan byte, done chan bool) {
+			for {
+				conn.SetDeadline(time.Now().Add(t.IOTimeout))
+				b, err := rdr.ReadByte()
+				switch {
+				case err == nil: // breaks switch
+				case err == io.EOF:
+					eof <- true
+					break
+				case strings.Contains(err.Error(), "i/o timeout"):
+					errs <- errNoMatchTimeout
+				default:
+					errs <- err
+					break
+				}
+				out <- b
+			}
+		}(reader, read, eof)
+
+		matched := make(chan bool)
+		// progressively read data until we hit EOF, timeout, or desired string
+		for {
+			// this won't loop infinitely b/c there's a timeout on the err chan
+			next := time.After(0)
+			select {
+			case <-matched: // have we already matched?
+				return &Status{Done: true, Message: "service available"}
+			case err := <-errs: // or encountered an error in reading?
+				return &Status{Done: true, Error: err}
+			case b := <-read:
+				// read a byte
+				content = append(content, b)
+				// does it match?
+				go func(current, expected []byte, match chan bool) {
+					if bytes.Contains(current, expected) {
+						match <- true
+					}
+				}(content, []byte(t.Content), matched)
+			case <-eof: // we've read everything and not gotten a match
+				return &Status{Done: true, Error: errNoMatch}
+			case <-next: // otherwise, keep trying
+				continue
+			}
+		}
+	}
+
+	// we're not matching content, and there was no connection error!
+	return &Status{Done: true, Message: "service available"}
+}

--- a/smlr/tcp_test.go
+++ b/smlr/tcp_test.go
@@ -1,0 +1,164 @@
+package smlr
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+)
+
+// only let failing test take .5s
+var half, _ = time.ParseDuration(".5s")
+
+// tcpServer accepts a single connection and writes response, returning the port
+// it's waiting on
+func tcpServer(response []byte, t *testing.T) (port int) {
+	// listen on a random port
+	var listen net.Listener
+	err := errors.New("")
+	for i := 0; i < 5 && err != nil; i++ {
+		port = rand.Intn(10000) + 1024
+		listen, err = net.Listen("tcp", fmt.Sprintf(":%v", port))
+	}
+	if err != nil {
+		t.Errorf("Error while creating TCP server: %v", err)
+		return port
+	}
+
+	// accept a single connection
+	go func(listener net.Listener) {
+		if listener != nil {
+			defer listener.Close()
+			conn, err := listener.Accept()
+			if err != nil {
+				t.Errorf("Error while accepting TCP connection: %v", err)
+			} else {
+				defer conn.Close()
+				if _, err = conn.Write(response); err != nil {
+					t.Errorf("Error while writing response to TCP connection: %v", err)
+				}
+			}
+		}
+	}(listen)
+
+	return port // return the randomly chosen port
+}
+
+func TestTCPNotUp(t *testing.T) {
+	t.Parallel()
+	waiter := TCPWaiter{URL: "http://localhost:10000", IOTimeout: half}
+
+	status := waiter.request(context.Background())
+	assert.Nil(t, status.Error)
+	assert.False(t, status.Done)
+	assert.Equal(t, "connection refused", status.Message)
+}
+
+func TestTCPBadServer(t *testing.T) {
+	t.Parallel()
+	waiter := TCPWaiter{URL: "tcp://some.bad.hostname/", IOTimeout: half}
+
+	status := waiter.request(context.Background())
+	assert.Nil(t, status.Error)
+	assert.False(t, status.Done)
+}
+
+func TestTCPBadContent(t *testing.T) {
+	t.Parallel()
+	port := tcpServer([]byte("not pong"), t)
+	waiter := TCPWaiter{
+		URL:           fmt.Sprintf("localhost:%v", port),
+		Content:       "pong",
+		EntireContent: true,
+		IOTimeout:     half,
+	}
+
+	status := waiter.request(context.Background())
+	assert.True(t, status.Done)
+	assert.Equal(t, "no content match", status.Error.Error())
+}
+
+func TestTCPBadContentPartial(t *testing.T) {
+	t.Parallel()
+	port := tcpServer([]byte("ping"), t)
+	waiter := TCPWaiter{
+		URL:           fmt.Sprintf("localhost:%v", port),
+		Content:       "pong",
+		EntireContent: false,
+		IOTimeout:     half,
+	}
+
+	status := waiter.request(context.Background())
+	assert.True(t, status.Done)
+	assert.Equal(t, "no content match", status.Error.Error())
+}
+
+func TestTCPGoodContent(t *testing.T) {
+	t.Parallel()
+	port := tcpServer([]byte("pong"), t)
+	waiter := TCPWaiter{
+		URL:           fmt.Sprintf("localhost:%v", port),
+		Content:       "pong",
+		EntireContent: true,
+		IOTimeout:     half,
+	}
+
+	status := waiter.request(context.Background())
+	assert.Nil(t, status.Error)
+	assert.True(t, status.Done)
+	assert.Equal(t, "service available", status.Message)
+}
+
+func TestTCPGoodContentPartial(t *testing.T) {
+	t.Parallel()
+	port := tcpServer([]byte("pong etc"), t)
+	waiter := TCPWaiter{
+		URL:           fmt.Sprintf("localhost:%v", port),
+		Content:       "pong",
+		EntireContent: false,
+		IOTimeout:     half,
+	}
+
+	status := waiter.request(context.Background())
+	assert.Nil(t, status.Error)
+	assert.True(t, status.Done)
+	assert.Equal(t, "service available", status.Message)
+}
+
+func TestTCPIOTimeout(t *testing.T) {
+	t.Parallel()
+	port := tcpServer([]byte("pong"), t)
+	waiter := TCPWaiter{
+		URL:       fmt.Sprintf("localhost:%v", port),
+		IOTimeout: 0,
+		Content:   "pong",
+	}
+
+	status := waiter.request(context.Background())
+	fmt.Println(status) // printing "service available"
+	assert.True(t, status.Done)
+	assert.NotNil(t, status.Error)
+	if status.Error != nil {
+		assert.Equal(t, "no content match within iotimeout", status.Error.Error())
+	}
+}
+
+func TestTCPWrite(t *testing.T) {
+	t.Parallel()
+	port := tcpServer([]byte("pong"), t)
+	waiter := TCPWaiter{
+		URL:       fmt.Sprintf("localhost:%v", port),
+		IOTimeout: half,
+		Write:     "ping",
+	}
+
+	status := waiter.request(context.Background())
+	assert.Nil(t, status.Error)
+	assert.True(t, status.Done)
+	assert.Equal(t, "service available", status.Message)
+}


### PR DESCRIPTION
Reads and matches from the connection concurrently.
Reads and writes are restricted by timeouts.

Fixes #2, #3

tested manually with these pairs of commands:

```
term1 $ nc -l -p 1234
term2 $ ./smlr-bin tcp localhost:1234
# succeeds

term1 $ nc -l -p 1234
term2 $ ./smlr-bin tcp --iotimeout 0s --content "pong" localhost:1234
# fails with timeout

term1 $ echo "pong" | nc -l -p 1234
term2 $ ./smlr-bin tcp --content "pong" localhost:1234
# succeeds

term1 $ echo "pong etc" | nc -l -p 1234
term2 $ ./smlr-bin tcp --content "pong" localhost:1234
# succeeds

term1 $ echo "pong etc" | nc -l -p 1234
term2 $ ./smlr-bin tcp --content "pong" --complete localhost:1234
# fails on timeout --- no EOF recieved

term1 $ echo "pong" | nc -l -p 1234
term2 $ ./smlr-bin tcp --content "pong" --complete localhost:1234
# fails on timeout --- no EOF recieved
```
